### PR TITLE
Add bng2latlong API to Places

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ APIs
 
 ### Places
 
+- [bng2latlong](https://www.getthedata.com/bng2latlong) - Convert an OSGB36 easting and northing (British National Grid) to WGS84 latitude and longitude.
 - [CityGrid](http://docs.citygridmedia.com/display/citygridv2/Places+API) - Enables developers to create web and mobile applications that find local businesses, organizations, and points of interest by a variety of search criteria.
 - [CountryAPI](https://fabian7593.github.io/CountryAPI/) - Gets all the countries, and obtain the most important information of these.
 - [Factual](http://developer.factual.com/get-started/) - Providing a places search that can be searched by latitude/longitude, and “where” using full text search query string.


### PR DESCRIPTION
bng2latlong takes an OSGB36 easting and northing, the geographical coordinates commonly used by the UK's national mapping authority, Ordnance Survey, and converts it to WGS84 latitude and longitude, e.g. for use in Google maps. This is a common requirement and would seem to best fit under "Places".