### PR TITLE
Remove Google's URL shorten service from the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,6 @@ APIs
 
 - [Anon.click](https://anon.click/api/) - Shorten long URLs and optionally protect them with passwords or captcha. No registration required.
 - [Bitly](http://dev.bitly.com/links.html) - Access to Bitly’s API.
-- [Google URL Shortener](https://developers.google.com/url-shortener/v1/) - Service that takes long URLs and squeezes them into fewer characters.
 - [Naver URL Shortener](https://developers.naver.com/products/shortenurl) - Access to Naver’s URL shortening API.
 - [Po.st](https://post.zendesk.com/hc/en-us/articles/200328516-Po-st-REST-API) - Shorten URLs, Expand shortened URLs, see statistics etc.
 - [ShrtURI](https://shrturi.com/docs) - URL shortening API for creating short URLs from long URLs.


### PR DESCRIPTION
Remove Google's URL shorten service from the list since the support was turned down as of March 30, 2018.