### PR TITLE
Removing Wunderlist - acquired and shutdown by Microsoft

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,6 @@ APIs
 - [Who Hosts This](https://www.who-hosts-this.com/API) - Detect the hosting provider powering any web site
 - [WolframAlpha](http://products.wolframalpha.com/api/) - Integrate top of the line computational knowledge into your applications through the WolframAlpha API. 💸
 - [WorldTimeAPI](http://worldtimeapi.org) - A JSON/plain-text which returns the (approx) current time for a provided timezone or IP. Targetted at limited-compute IoT devices.
-- [Wunderlist](https://developer.wunderlist.com/) - The Wunderlist API provides REST-based storage and synchronization of a user’s lists across multiple platforms and devices.
 
 ### Movies
 


### PR DESCRIPTION
Hey @n0shake 

Wunderlist has been acquired and shutdown by Microsoft.

Cheers,
Peter