### PR TITLE
Added Coingecko API

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ APIs
 - [CryptoCompare](https://www.cryptocompare.com/api) - Cryptocurrencies Comparison
 - [Cryptonator](https://www.cryptonator.com/api/) - Cryptocurrencies Exchange Rates
 - [Coinigy](https://coinigy.docs.apiary.io) - Interact with Coinigy Accounts and Exchange Accounts Directly
+- [Coingecko](https://www.coingecko.com/en/api) - Free and Public Cryptocurrency API which you can use without an API key.
 - [Exchange Rates API](https://blockchain.info/api/exchange_rates_api) - Market Prices and exchanges rates api.
 - [ShapeShift.io](https://shapeshift.io/) - Exchange between cryptocurrencies without an account.  Well documented API for easy use.
 - [Technical Analysis](https://technical-analysis-api.com) - Cryptocurrency prices, technical analysis and sentiment detection.


### PR DESCRIPTION
Out of all the crypto APIs, coingecko is the only public API you can use without an API key. I think people should be aware of that.