### PR TITLE
add TCGdex API

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**Rick and Morty**](https://rickandmortyapi.com/) | All the Rick and Morty information, including images. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
 | [**Star Wars API (SWAPI)**](https://www.swapi.tech/) | All things Star Wars, based on Wookpedia and other sources. Reboot of original swapi.co, guaranteed to be maintained. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
 | [**Studio Ghibli**](https://ghibliapi.herokuapp.com/) | Resources from Studio Ghibli films. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
+| [**TCGdex**](https://www.tcgdex.dev/) | A Multilanguage Pokémon TCG Database with Cards Pictures and most of the informations contained on the cards. ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
 
 [⬆ Back to Table of Contents](#table-of-contents)
 ### Events


### PR DESCRIPTION
Add the TCGdex API, the URL is the new API website but currently redirect to the current documentation page