### PR TITLE
Add Anilist to Entertainment

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 ### Entertainment
 | API | Description | Open/Trial |
 | --- | ----------- | ---- |
+| [**Anilist**](https://anilist.gitbook.io/anilist-apiv2-docs/) | Free Graphql api for thousands of animes, mangas, characters and staff | **N/A** |
 | [**Animechan**](https://animechan.vercel.app/guide) | Free restful API providing anime quotes. | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")|
 | [**Bob's Burgers API**](https://www.bobsburgersapi.com/documentation) | Get data for hundreds of characters, episodes, running gags, and images from the show. | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") |
 | [**Breaking Bad & Better Call Saul API**](https://breakingbadapi.com/documentation) | Get data about characters, episodes, quotes, and deaths. | **N/A** |


### PR DESCRIPTION
add [anilist](https://anilist.co)'s api to entertainment section. Linked to the api [docs](https://anilist.gitbook.io/anilist-apiv2-docs/)