### PR TITLE
Add DigiDates API to Calendar category and fix a minor syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 ### Quotes
 | API | Description | Open/Trial |
 | --- | ----------- | ---- |
-| [**Breaking Bad**](https://breakingbadquotes.xyz) | Gives quotes from "Breaking Bad". | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source")
+| [**Breaking Bad**](https://breakingbadquotes.xyz) | Gives quotes from "Breaking Bad". | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") |
 | [**FavQs**](https://favqs.com/api) | FavQs allows you to collect, discover, and share your favorite quotes. | **N/A** |
 | [**Forismatic**](http://api.forismatic.com/api/1.0/) | Gives you a random quote per click. | **N/A** |
 | [**Hindi Quotes**](https://hindi-quotes.vercel.app/) | Get random Hindi quotes of different categories.| ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") |

--- a/README.md
+++ b/README.md
@@ -155,10 +155,11 @@ This is an attempt to categorise different APIs scoured from the web which make 
 
 [⬆ Back to Table of Contents](#table-of-contents)
 ### Calendar
-| API | Description | Open/Trial |
-| --- | ----------- | ---- |
-| [**CalendarIndex**](https://www.calendarindex.com) | Worldwide Holidays and Working Days API. | **N/A** |
-| [**Holiday API**](https://holidayapi.pl/) | Public holiday API service for several supported countries. | **N/A** |
+| API                                                | Description                                                 | Open/Trial |
+|----------------------------------------------------|-------------------------------------------------------------| ---- |
+| [**CalendarIndex**](https://www.calendarindex.com) | Worldwide Holidays and Working Days API.                    | **N/A** |
+| [**DigiDates API**](https://digidates.de/en/)      | Rest API for date and time calculations.                    | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png) |
+| [**Holiday API**](https://holidayapi.pl/)          | Public holiday API service for several supported countries. | **N/A** |
 
 [⬆ Back to Table of Contents](#table-of-contents)
 ### Captcha


### PR DESCRIPTION
Add DigiDates API to Calendar category
Fix a minor Markdown syntax error
