### PR TITLE
Remove GoTiny from URL Shorteners

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,7 +791,6 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | API | Description | Open/Trial |
 | --- | ----------- | ---- |
 | [**Bitly**](http://dev.bitly.com/links.html) | Access to Bitly’s API. | **N/A** |
-| [**GoTiny**](https://github.com/robvanbakel/gotiny-api) | Lightweight and easy to implement URL shortener. Supports custom links and offers JavaScript SDK. | **N/A** |
 | [**Is.gd**](https://is.gd/developers.php) | Simple URL shortener. Supports custom short link ending. | **N/A** |
 | [**Shrtcode**](https://shrtco.de/docs) | Free and unlimited URL shortening API without authentication. | **N/A** |
 | [**ShrtURI**](https://shrturi.com/docs) | URL shortening API for creating short URLs from long URLs. | **N/A** |


### PR DESCRIPTION
GoTiny is a API that I built that I had to close down and is no longer available.

Please ensure your pull request adheres to the following guidelines:

- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] Make an individual pull request for each suggestion.
- [x] Titles should be capitalized.
- [x] Keep descriptions short and simple.
- [x] End all descriptions with a full stop/period.
- [x] Check your spelling and grammar.
- [x] Make sure your text editor is set to remove trailing whitespace.
- [x] Try to make your Pull request and title as descriptive as possible.
- [x] Mark open source APIs with the open source icon
- [x] Mark all trial/demo based APIs with the 💸 emoticon.
- [x] Keep the APIs sorted alphabetically.
- [x] Whenever possible link directly to the documentation page!
